### PR TITLE
TranslationMethods::isEmpty() return always false > FIXED

### DIFF
--- a/src/Model/Translatable/TranslationMethods.php
+++ b/src/Model/Translatable/TranslationMethods.php
@@ -82,6 +82,14 @@ trait TranslationMethods
      */
     public function isEmpty()
     {
-        return false;
+        foreach (get_object_vars($this) as $var => $value) {
+            if (in_array($var, array('id', 'translatable', 'locale')))
+                continue;
+
+            if (!empty($value))
+                return false;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
Test the value of each variables if null.
Return true in case that all variables are null, the translation will faillback on the default locale.
